### PR TITLE
doc(README) : Uses DuckDB 1.0.0 "Nivis" by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ This action installs [`duckdb`](https://github.com/duckdb/duckdb) with the versi
 ## 🚀 Example usage
 
 ```yaml
-uses: opt-nc/setup-duckdb-action@v1.0.7
+uses: opt-nc/setup-duckdb-action@v1.0.8
 with:
-  version: v0.10.1
+  version: v1.0.0
 ```
 
 ```yaml
-uses: opt-nc/setup-duckdb-action@v1.0.7
+uses: opt-nc/setup-duckdb-action@v1.0.8
 ```
 
 ## 📑 Related resources


### PR DESCRIPTION
# :grey_question: Context

DuckDB 1.0.0 "Nivis"](https://github.com/duckdb/duckdb/releases/tag/v1.0.0) has been released and makes a huge jump forward.
By default, everyone should use this latest  `duckdb` version.


# :dart: Goal

Merging : 

- [ ]  this PR will document that, making code samples point to that version
- [ ] https://github.com/opt-nc/setup-duckdb-action/pull/103
- [ ] https://github.com/opt-nc/setup-duckdb-action/pull/101
- [ ] Release a new version for the action

