### PR TITLE
doc: Target `v1.1.2` by default in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This action installs [`duckdb`](https://github.com/duckdb/duckdb) with the versi
 ```yaml
 uses: opt-nc/setup-duckdb-action@v1.0.8
 with:
-  version: v1.0.0
+  version: v1.1.2
 ```
 
 ```yaml


### PR DESCRIPTION
# :grey_question: About

[`v1.1.2`](https://github.com/duckdb/duckdb/releases/tag/v1.1.2) has been released, cf [tweet](https://x.com/duckdb/status/1845814030318829816) : 

![Image](https://github.com/user-attachments/assets/dc0770d4-4c10-403a-8977-46de3375fcee)

# :dart: Actions

This PR documents the most up-to-date version.
